### PR TITLE
Remove duplicative out of scope clause

### DIFF
--- a/charters/Proposed-WG-WebIdentityCredentials.md
+++ b/charters/Proposed-WG-WebIdentityCredentials.md
@@ -13,7 +13,7 @@ The *W3C Web Identity Credential Working Group* will develop living standard spe
 
 ## Scope
 
-The Working Group will specify new web platform features intended to be implemented in browsers or similar user agents. The purpose of these features is to support authentication and authorization flows without compromising security principles for Identity Providers (IdPs), Relying Parties (RPs), and User Agents as well as user privacy. Here "privacy" minimally refers to the appropriate processing of personal information. The result of this work is the development of new mechanisms that define how information is passed by the browser between the RP, the IdP and authentication intermediaries to facilitate federated authentication; it is not an authentication method.
+The Working Group will specify new web platform features intended to be implemented in browsers or similar user agents. The purpose of these features is to support authentication and authorization flows without compromising security principles for Identity Providers (IdPs), Relying Parties (RPs), and User Agents as well as user privacy. Here "privacy" minimally refers to the appropriate processing of personal information. The result of this work is the development of new mechanisms that define how information is passed by the browser between the RP, the IdP, and authentication intermediaries to facilitate federated authentication.
 
 If any of the mechanisms developed to support authentication and authorization flows look like they will result in breaking changes for existing protocols, work on that mechanism must include a well-documented transition period.
 


### PR DESCRIPTION
It wasn't clear what "it" referred to in this little addendum, but then I realized that there was an explicit "out of scope" section for saying these sorts of things.

Added an Oxford comma for good measure.